### PR TITLE
chore: rename `MultipartStreamFactory`

### DIFF
--- a/backwards-compatibility.php
+++ b/backwards-compatibility.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+use Boesing\Psr\Http\Message\Multipart\MultipartStreamFactory;
+use Boesing\Psr\Http\Message\Multipart\MutltipartStreamFactory;
+
+class_alias(MultipartStreamFactory::class, MutltipartStreamFactory::class);

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
     "autoload": {
         "psr-4": {
             "Boesing\\Psr\\Http\\Message\\Multipart\\": "src/"
-        }
+        },
+        "files": [
+            "backwards-compatibility.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -33,7 +33,7 @@ final class ConfigProvider
         return [
             'factories' => [
                 MimeTypeGuesserInterface::class              => static fn(): MimeTypeGuesserInterface => new SymfonyMimeMimeTypeGuesser(new MimeTypes()),
-                MultipartStreamFactoryInterface::class       => static fn(ContainerInterface $container): MultipartStreamFactoryInterface => new MutltipartStreamFactory(
+                MultipartStreamFactoryInterface::class       => static fn(ContainerInterface $container): MultipartStreamFactoryInterface => new MultipartStreamFactory(
                     $container->get(StreamFactoryInterface::class),
                     $container->get(PartOfMultipartStreamFactoryInterface::class)
                 ),

--- a/src/MultipartStreamFactory.php
+++ b/src/MultipartStreamFactory.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
 
 use function array_values;
 
-final class MutltipartStreamFactory implements MultipartStreamFactoryInterface
+final class MultipartStreamFactory implements MultipartStreamFactoryInterface
 {
     public function __construct(
         private readonly StreamFactoryInterface $streamFactory,

--- a/test/unit/MultipartStreamFactoryTest.php
+++ b/test/unit/MultipartStreamFactoryTest.php
@@ -20,7 +20,7 @@ final class MultipartStreamFactoryTest extends TestCase
 
     private PartOfMultipartStreamFactoryInterface&MockObject $partOfMultipartStreamFactory;
 
-    private MutltipartStreamFactory $multipartStreamFactory;
+    private MultipartStreamFactory $multipartStreamFactory;
 
     private MockObject&StreamInterface $stream;
 
@@ -37,7 +37,7 @@ final class MultipartStreamFactoryTest extends TestCase
             ->method('createStream')
             ->willReturn($this->stream);
         $this->partOfMultipartStreamFactory = $this->createMock(PartOfMultipartStreamFactoryInterface::class);
-        $this->multipartStreamFactory       = new MutltipartStreamFactory(
+        $this->multipartStreamFactory       = new MultipartStreamFactory(
             $this->streamFactory,
             $this->partOfMultipartStreamFactory
         );


### PR DESCRIPTION
This also adds a backwards compatibility layer for projects which - whyever - instantiating the class directly.